### PR TITLE
Psing/fix codacy init

### DIFF
--- a/hamb/ham_run_utility.py
+++ b/hamb/ham_run_utility.py
@@ -55,7 +55,8 @@ class HandlerEngine(object):
             class_ = getattr(mod, "Handler")
             class_(CONF).setup().run(result, list(handler.values())[0])
 
-    def get_handler_config(self, service, level, file_location=None):
+    @staticmethod
+    def get_handler_config(service, level, file_location=None):
         """
 
         :param manifest:
@@ -66,7 +67,7 @@ class HandlerEngine(object):
             file_location = "services.yaml"
         with open(file_location, "r") as services_yaml:
             try:
-                obj = yaml.load(services_yaml)
+                obj = yaml.safe_load(services_yaml)
             except Exception as e:
                 LOG.l_exception(f"issue parsing yaml: {e}")
                 exit(1)
@@ -188,7 +189,6 @@ class TestEngine(object):
                 )
             except Exception as e:
                 print(f"cannot write results to database: {e}")
-                pass
 
         if failed_cnt > 0:
             overall_status = "failure"
@@ -212,7 +212,8 @@ class TestEngine(object):
 
         return result
 
-    def manifest_reader(self, manifest, file_location=None):
+    @staticmethod
+    def manifest_reader(manifest, file_location=None):
         """
 
         :param manifest:
@@ -222,7 +223,7 @@ class TestEngine(object):
             file_location = "manifests/%s.yaml"
         with open(file_location % manifest, "r") as checklist_yaml:
             try:
-                test_config = yaml.load(checklist_yaml)
+                test_config = yaml.safe_load(checklist_yaml)
             except Exception as e:
                 LOG.l_exception(f"issue parsing yaml, please check: {e}")
         return test_config

--- a/hamb/sample_test_failed_handler.py
+++ b/hamb/sample_test_failed_handler.py
@@ -22,7 +22,7 @@ class SqlComp(object):
 
     def setup(self, CONF):
         print("Setting up...")
-        pass
+        #pass
 
         return self
 

--- a/hamb/sample_test_handler.py
+++ b/hamb/sample_test_handler.py
@@ -22,7 +22,7 @@ class SqlComp(object):
 
     def setup(self, CONF):
         print("Setting up...")
-        pass
+        #pass
 
         return self
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,10 @@
 -r requirements.txt
 black==19.3b0
 tox==2.9.1
-pytest==5.1.2
+pytest==5.2.0
 pytest-cov==2.7.1
 pre-commit==1.18.3
 recommonmark==0.6.0
 sphinx-rtd-theme==0.4.3
 sphinx==2.2.0
+attrs==19.1.0

--- a/tests/unit/test_ham_run.py
+++ b/tests/unit/test_ham_run.py
@@ -61,5 +61,6 @@ class TestHamrun(unittest.TestCase):
             result = self.TestEngine.run("sample")
             self.HandlerEngine.run("sample", result)
 
-    def test_json_serial(self):
+    @staticmethod
+    def test_json_serial():
         json_serial(datetime.datetime(2015, 2, 1, 15, 16, 17, 345))

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,5 @@ whitelist_externals = mkdir
 changedir = tests
 deps=-rrequirements-dev.txt
 commands=
-    pytest --cov=hambot --disable-pytest-warnings --cov-report html
+    pytest --cov=hamb --disable-pytest-warnings --cov-report html
 


### PR DESCRIPTION
Description
Fix issues reported by codacy. 

- Made some methods staticmethods since they don't use the self variable
- update yaml to use safe_load

Test Plan
Run tox and see if the tests will run successfully. (Note: I'm seeing tests fail on py3.5.0, but succeeding on 3.6.5)