### PR TITLE
Updated requirements to use latest datacoco repos.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-datacoco==0.1
+datacoco>=0.1.3
 pyyaml==5.1
 slackclient==1.3.0
 redis==2.10.6

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 from hamb import VERSION
 
 requires = [
-    "datacoco==0.1",
+    "datacoco>=0.1.3",
     "pyyaml==3.13",
     "slackclient==1.3.0",
     "redis==2.10.6",


### PR DESCRIPTION
The dependencies were causing all of the warnings from an old version of SQLAlchemy.